### PR TITLE
Remove require-unicode-regexp rule

### DIFF
--- a/shareable-config.yaml
+++ b/shareable-config.yaml
@@ -145,7 +145,6 @@ rules:
   prefer-promise-reject-errors: [error]
   radix: [error, always]
   require-await: [error]
-  require-unicode-regexp: [error]
   vars-on-top: [error]
   wrap-iife: [error, inside, { functionPrototypeMethods: true }]
   yoda: [error, never]


### PR DESCRIPTION
Causes issues in IE11: [https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode#Browser_compatibility](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode#Browser_compatibility)